### PR TITLE
Add proper lexer for .env files

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 5
     paths:
         - src
     ignoreErrors:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,5 @@
 parameters:
+    reportUnmatchedIgnoredErrors: false
     level: 5
     paths:
         - src
-    ignoreErrors:
-        - message: '#Access to an undefined property.*?\$expr#'
-          path: src/ArrayFile.php

--- a/src/ArrayFile.php
+++ b/src/ArrayFile.php
@@ -155,6 +155,7 @@ class ArrayFile extends DataFile implements DataFileInterface
             if ($target->value->name->parts[0] !== 'env' || !isset($target->value->args[0])) {
                 return $this;
             }
+            /* @phpstan-ignore-next-line */
             if (isset($target->value->args[0]) && !isset($target->value->args[1])) {
                 $target->value->args[1] = new Arg($this->makeAstNode($valueType, $value));
             }

--- a/src/ArrayFile.php
+++ b/src/ArrayFile.php
@@ -26,11 +26,6 @@ class ArrayFile extends DataFile implements DataFileInterface
     const SORT_DESC = 'desc';
 
     /**
-     * @var Stmt[]|null Abstract syntax tree produced by `PhpParser`
-     */
-    protected ?array $ast = null;
-
-    /**
      * Lexer for use by `PhpParser`
      */
     protected ?Lexer $lexer = null;

--- a/src/ArrayFile.php
+++ b/src/ArrayFile.php
@@ -20,7 +20,7 @@ use Winter\LaravelConfigWriter\Parser\PHPConstant;
 use Winter\LaravelConfigWriter\Parser\PHPFunction;
 use Winter\LaravelConfigWriter\Printer\ArrayPrinter;
 
-class ArrayFile implements DataFileInterface
+class ArrayFile extends DataFile implements DataFileInterface
 {
     const SORT_ASC = 'asc';
     const SORT_DESC = 'desc';
@@ -442,15 +442,5 @@ class ArrayFile implements DataFileInterface
     public function render(): string
     {
         return $this->printer->render($this->ast, $this->lexer) . "\n";
-    }
-
-    /**
-     * Get currently loaded AST
-     *
-     * @return Stmt[]|null
-     */
-    public function getAst()
-    {
-        return $this->ast;
     }
 }

--- a/src/Contracts/DataFileLexerInterface.php
+++ b/src/Contracts/DataFileLexerInterface.php
@@ -4,8 +4,17 @@ namespace Winter\LaravelConfigWriter\Contracts;
 
 interface DataFileLexerInterface
 {
+    public const T_ENV = 'T_ENV';
+    public const T_QUOTED_ENV = 'T_QUOTED_ENV';
+    public const T_ENV_NO_VALUE = 'T_ENV_NO_VALUE';
+    public const T_WHITESPACE = 'T_WHITESPACE';
+    public const T_COMMENT = 'T_COMMENT';
+
     /**
      * Get the ast from array of src lines
+     *
+     * @param array<int, string> $src
+     * @return array<int, array>
      */
     public function parse(array $src): array;
 }

--- a/src/Contracts/DataFileLexerInterface.php
+++ b/src/Contracts/DataFileLexerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Winter\LaravelConfigWriter\Contracts;
+
+interface DataFileLexerInterface
+{
+    /**
+     * Get the ast from array of src lines
+     */
+    public function parse(array $src): array;
+}

--- a/src/Contracts/DataFileLexerInterface.php
+++ b/src/Contracts/DataFileLexerInterface.php
@@ -5,16 +5,16 @@ namespace Winter\LaravelConfigWriter\Contracts;
 interface DataFileLexerInterface
 {
     public const T_ENV = 'T_ENV';
-    public const T_QUOTED_ENV = 'T_QUOTED_ENV';
-    public const T_ENV_NO_VALUE = 'T_ENV_NO_VALUE';
+    public const T_VALUE = 'T_VALUE';
+    public const T_QUOTED_VALUE = 'T_QUOTED_VALUE';
     public const T_WHITESPACE = 'T_WHITESPACE';
     public const T_COMMENT = 'T_COMMENT';
 
     /**
      * Get the ast from array of src lines
      *
-     * @param array<int, string> $src
+     * @param string $string
      * @return array<int, array>
      */
-    public function parse(array $src): array;
+    public function parse(string $string): array;
 }

--- a/src/Contracts/DataFilePrinterInterface.php
+++ b/src/Contracts/DataFilePrinterInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Winter\LaravelConfigWriter\Contracts;
+
+interface DataFilePrinterInterface
+{
+    /**
+     * Transform the ast back to a src file string
+     */
+    public function render(array $ast): string;
+}

--- a/src/Contracts/DataFilePrinterInterface.php
+++ b/src/Contracts/DataFilePrinterInterface.php
@@ -6,6 +6,8 @@ interface DataFilePrinterInterface
 {
     /**
      * Transform the ast back to a src file string
+     * @param array<int, array> $ast
+     * @return string
      */
     public function render(array $ast): string;
 }

--- a/src/DataFile.php
+++ b/src/DataFile.php
@@ -7,6 +7,13 @@ use Winter\LaravelConfigWriter\Contracts\DataFileInterface;
 abstract class DataFile implements DataFileInterface
 {
     /**
+     * Abstract syntax tree
+     *
+     * @var \PhpParser\Node\Stmt[]|array<int, array>
+     */
+    protected $ast = [];
+
+    /**
      * Get currently loaded AST
      *
      * @return \PhpParser\Node\Stmt[]|array|null

--- a/src/DataFile.php
+++ b/src/DataFile.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Winter\LaravelConfigWriter;
+
+use Winter\LaravelConfigWriter\Contracts\DataFileInterface;
+
+abstract class DataFile implements DataFileInterface
+{
+    /**
+     * Get currently loaded AST
+     *
+     * @return \PhpParser\Node\Stmt[]|array|null
+     */
+    public function getAst()
+    {
+        return $this->ast;
+    }
+}

--- a/src/DataFile.php
+++ b/src/DataFile.php
@@ -9,7 +9,7 @@ abstract class DataFile implements DataFileInterface
     /**
      * Abstract syntax tree
      *
-     * @var \PhpParser\Node\Stmt[]|array<int, array>
+     * @var mixed
      */
     protected $ast = [];
 

--- a/src/EnvFile.php
+++ b/src/EnvFile.php
@@ -195,7 +195,7 @@ class EnvFile implements DataFileInterface
                 continue;
             }
 
-            $env[$item['env']['key']] = $item['env']['value'];
+            $env[$item['env']['key']] = trim($item['env']['value']);
         }
 
         return $env;

--- a/src/EnvFile.php
+++ b/src/EnvFile.php
@@ -107,8 +107,8 @@ class EnvFile extends DataFile implements DataFileInterface
                 switch ($this->ast[$index + 1]['token']) {
                     case $this->lexer::T_VALUE:
                         if (
-                            str_contains($this->ast[$index + 1]['value'], '"')
-                            || str_contains($this->ast[$index + 1]['value'], '\'')
+                            strpos($this->ast[$index + 1]['value'], '"') !== false
+                            || strpos($this->ast[$index + 1]['value'], '\'') !== false
                         ) {
                             $this->ast[$index + 1]['token'] = $this->lexer::T_QUOTED_VALUE;
                         }

--- a/src/EnvFile.php
+++ b/src/EnvFile.php
@@ -98,7 +98,11 @@ class EnvFile extends DataFile implements DataFileInterface
                     !isset($this->ast[$index + 1])
                     || !in_array($this->ast[$index + 1]['token'], [$this->lexer::T_VALUE, $this->lexer::T_QUOTED_VALUE])
                 ) {
-                    throw new \Exception('jack go fix');
+                    // The next token was not a value, we need to create an empty value node to allow for value setting
+                    array_splice($this->ast, $index + 1, 0, [[
+                        'token' => $this->lexer::T_VALUE,
+                        'value' => ''
+                    ]]);
                 }
 
                 $this->ast[$index + 1]['value'] = $this->castValue($value);

--- a/src/EnvFile.php
+++ b/src/EnvFile.php
@@ -16,7 +16,7 @@ class EnvFile implements DataFileInterface
     /**
      * Lines of env data
      *
-     * @var array<int, array<int, mixed>>
+     * @var array<int, array>
      */
     protected array $ast = [];
 

--- a/src/EnvFile.php
+++ b/src/EnvFile.php
@@ -14,13 +14,6 @@ use Winter\LaravelConfigWriter\Printer\EnvPrinter;
 class EnvFile extends DataFile implements DataFileInterface
 {
     /**
-     * Lines of env data
-     *
-     * @var array<int, array>
-     */
-    protected array $ast = [];
-
-    /**
      * Env file lexer, used to generate ast from src
      *
      * @var DataFileLexerInterface

--- a/src/EnvFile.php
+++ b/src/EnvFile.php
@@ -105,7 +105,7 @@ class EnvFile implements DataFileInterface
                     is_numeric($value)
                     || is_bool($value)
                     || is_null($value)
-                    || (is_string($value) && !str_contains($value, ' ') && $item['token'] === $this->lexer::T_ENV)
+                    || (is_string($value) && strpos($value, ' ') === false && $item['token'] === $this->lexer::T_ENV)
                 ) ? $this->lexer::T_ENV : $this->lexer::T_QUOTED_ENV;
 
                 return $this;

--- a/src/Exceptions/EnvParserException.php
+++ b/src/Exceptions/EnvParserException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Winter\LaravelConfigWriter\Exceptions;
+
+class EnvParserException extends \Exception
+{
+}

--- a/src/Parser/EnvLexer.php
+++ b/src/Parser/EnvLexer.php
@@ -54,6 +54,15 @@ class EnvLexer implements DataFileLexerInterface
 
             switch ($name) {
                 case static::T_ENV:
+                    return [
+                        'match' => $matches[0],
+                        'env' => [
+                            'key' => $matches[1],
+                            'value' => trim($matches[2]),
+                        ],
+                        'token' => $name,
+                        'line' => $line + 1
+                    ];
                 case static::T_QUOTED_ENV:
                     return [
                         'match' => $matches[0],

--- a/src/Parser/EnvLexer.php
+++ b/src/Parser/EnvLexer.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Winter\LaravelConfigWriter\Parser;
+
+use Winter\LaravelConfigWriter\Contracts\DataFileLexerInterface;
+use Winter\LaravelConfigWriter\Exceptions\EnvParserException;
+
+class EnvLexer implements DataFileLexerInterface
+{
+    public const T_ENV = 'T_ENV';
+    public const T_QUOTED_ENV = 'T_QUOTED_ENV';
+    public const T_ENV_NO_VALUE = 'T_ENV_NO_VALUE';
+    public const T_WHITESPACE = 'T_WHITESPACE';
+    public const T_COMMENT = 'T_COMMENT';
+
+    protected $tokenMap = [
+        '/^([\w]*)="?(.+)["|$]/'      => self::T_QUOTED_ENV,
+        '/^([\w]*)="?(.*)(?:"|$)/'    => self::T_ENV,
+        '/^(\w+)/'                    => self::T_ENV_NO_VALUE,
+        '/^(\s+)/'                    => self::T_WHITESPACE,
+        '/(#[\w\s]).*/'               => self::T_COMMENT,
+    ];
+
+    public function parse(array $src): array
+    {
+        $tokens = [];
+
+        foreach ($src as $line => $str) {
+            $read = 0;
+            do {
+                $result = $this->match($str, $line, $read);
+
+                if (is_null($result)) {
+                    throw new EnvParserException("Unable to parse line " . ($line + 1) . ".");
+                }
+
+                $tokens[] = $result;
+
+                $read += strlen($result['match']);
+            } while ($read < strlen($str));
+        }
+
+        return $tokens;
+    }
+
+    public function match(string $str, int $line, int $offset): ?array
+    {
+        $str = substr($str, $offset);
+
+        foreach ($this->tokenMap as $pattern => $name) {
+            if (!preg_match($pattern, $str, $matches)) {
+                continue;
+            }
+
+            switch ($name) {
+                case static::T_ENV:
+                case static::T_QUOTED_ENV:
+                    return [
+                        'match' => $matches[0],
+                        'env' => [
+                            'key' => $matches[1],
+                            'value' => $matches[2],
+                        ],
+                        'token' => $name,
+                        'line' => $line + 1
+                    ];
+                case static::T_ENV_NO_VALUE:
+                    return [
+                        'match' => $matches[0],
+                        'env' => [
+                            'key' => $matches[1],
+                            'value' => '',
+                        ],
+                        'token' => $name,
+                        'line' => $line + 1
+                    ];
+                case static::T_COMMENT:
+                    return [
+                        'match' => $matches[0],
+                        'token' => $name,
+                        'line' => $line + 1
+                    ];
+                case static::T_WHITESPACE:
+                    return [
+                        'match' => $matches[1],
+                        'token' => $name,
+                        'line' => $line + 1
+                    ];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Parser/EnvLexer.php
+++ b/src/Parser/EnvLexer.php
@@ -54,15 +54,6 @@ class EnvLexer implements DataFileLexerInterface
 
             switch ($name) {
                 case static::T_ENV:
-                    return [
-                        'match' => $matches[0],
-                        'env' => [
-                            'key' => $matches[1],
-                            'value' => trim($matches[2]),
-                        ],
-                        'token' => $name,
-                        'line' => $line + 1
-                    ];
                 case static::T_QUOTED_ENV:
                     return [
                         'match' => $matches[0],

--- a/src/Parser/EnvLexer.php
+++ b/src/Parser/EnvLexer.php
@@ -7,12 +7,6 @@ use Winter\LaravelConfigWriter\Exceptions\EnvParserException;
 
 class EnvLexer implements DataFileLexerInterface
 {
-    public const T_ENV = 'T_ENV';
-    public const T_QUOTED_ENV = 'T_QUOTED_ENV';
-    public const T_ENV_NO_VALUE = 'T_ENV_NO_VALUE';
-    public const T_WHITESPACE = 'T_WHITESPACE';
-    public const T_COMMENT = 'T_COMMENT';
-
     protected $tokenMap = [
         '/^([\w]*)="?(.+)["|$]/'      => self::T_QUOTED_ENV,
         '/^([\w]*)="?(.*)(?:"|$)/'    => self::T_ENV,

--- a/src/Printer/EnvPrinter.php
+++ b/src/Printer/EnvPrinter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Winter\LaravelConfigWriter\Printer;
+
+use Winter\LaravelConfigWriter\Contracts\DataFilePrinterInterface;
+use Winter\LaravelConfigWriter\Parser\EnvLexer;
+
+class EnvPrinter implements DataFilePrinterInterface
+{
+    public function render(array $ast): string
+    {
+        $output = '';
+
+        foreach ($ast as $item) {
+            switch ($item['token']) {
+                case EnvLexer::T_ENV:
+                    $output .= sprintf('%s=%s', $item['env']['key'], $item['env']['value']);
+                    break;
+                case EnvLexer::T_QUOTED_ENV:
+                    $output .= sprintf('%s="%s"', $item['env']['key'], $item['env']['value']);
+                    break;
+                case EnvLexer::T_ENV_NO_VALUE:
+                    $output .= $item['env']['key'];
+                    break;
+                case EnvLexer::T_COMMENT:
+                case EnvLexer::T_WHITESPACE:
+                    $output .= $item['match'];
+                    break;
+            }
+        }
+
+        return $output;
+    }
+}

--- a/src/Printer/EnvPrinter.php
+++ b/src/Printer/EnvPrinter.php
@@ -14,13 +14,13 @@ class EnvPrinter implements DataFilePrinterInterface
         foreach ($ast as $item) {
             switch ($item['token']) {
                 case EnvLexer::T_ENV:
-                    $output .= sprintf('%s=%s', $item['env']['key'], $item['env']['value']);
+                    $output .= $item['value'];
                     break;
-                case EnvLexer::T_QUOTED_ENV:
-                    $output .= sprintf('%s="%s"', $item['env']['key'], $item['env']['value']);
+                case EnvLexer::T_VALUE:
+                    $output .= sprintf('=%s', $item['value']);
                     break;
-                case EnvLexer::T_ENV_NO_VALUE:
-                    $output .= $item['env']['key'];
+                case EnvLexer::T_QUOTED_VALUE:
+                    $output .= sprintf('="%s"', $item['value']);
                     break;
                 case EnvLexer::T_COMMENT:
                 case EnvLexer::T_WHITESPACE:

--- a/tests/EnvFileTest.php
+++ b/tests/EnvFileTest.php
@@ -93,7 +93,7 @@ class EnvFileTest extends TestCase
         $this->assertStringContainsString('APP_KEY="winter"', $result);
         $this->assertStringContainsString('DB_USE_CONFIG_FOR_TESTING=false', $result);
         $this->assertStringContainsString('MAIL_HOST="smtp.mailgun.org"', $result);
-        $this->assertStringContainsString('ROUTES_CACHE="winter"', $result);
+        $this->assertStringContainsString('ROUTES_CACHE=winter', $result);
         $this->assertStringContainsString('ENABLE_CSRF=true', $result);
         $this->assertStringContainsString('# HELLO WORLD', $result);
         $this->assertStringContainsString('#ENV_TEST="wintercms"', $result);
@@ -188,5 +188,29 @@ class EnvFileTest extends TestCase
         $env = EnvFile::open($filePath);
 
         $this->assertEquals(file_get_contents($filePath), $env->render());
+    }
+
+    public function testHandleEdgeCases()
+    {
+        $filePath = __DIR__ . '/fixtures/env/edge-cases.env';
+
+        $env = EnvFile::open($filePath);
+
+        $this->assertEquals(file_get_contents($filePath), $env->render());
+    }
+
+    public function testUpdateEnvWithTrailingComment()
+    {
+        $filePath = __DIR__ . '/fixtures/env/edge-cases.env';
+
+        $env = EnvFile::open($filePath);
+
+        $env->set('APP_KEY', '123');
+        $result = $env->render();
+        $this->assertStringContainsString('APP_KEY=123 # Change this', $result);
+
+        $env->set('APP_KEY', 'this is a test');
+        $result = $env->render();
+        $this->assertStringContainsString('APP_KEY="this is a test" # Change this', $result);
     }
 }

--- a/tests/EnvFileTest.php
+++ b/tests/EnvFileTest.php
@@ -218,5 +218,9 @@ class EnvFileTest extends TestCase
         $env->set('APP_KEY', 'this is a test');
         $result = $env->render();
         $this->assertStringContainsString('APP_KEY="this is a test" # Change this', $result);
+
+        $env->set('VAR_NO_VALUE', 'this is a test');
+        $result = $env->render();
+        $this->assertStringContainsString('VAR_NO_VALUE=this is a test', $result);
     }
 }

--- a/tests/EnvFileTest.php
+++ b/tests/EnvFileTest.php
@@ -158,7 +158,13 @@ class EnvFileTest extends TestCase
         $env->write($tmpFile);
 
         $result = file_get_contents($tmpFile);
-        $this->assertStringContainsString('APP_KEY=123', $result);
+        $this->assertStringContainsString('APP_KEY="123"', $result);
+
+        $env->set(['APP_KEY2' => '123']);
+        $env->write($tmpFile);
+
+        $result = file_get_contents($tmpFile);
+        $this->assertStringContainsString('APP_KEY2=123', $result);
 
         $env->set(['APP_KEY' => true]);
         $env->write($tmpFile);
@@ -207,7 +213,7 @@ class EnvFileTest extends TestCase
 
         $env->set('APP_KEY', '123');
         $result = $env->render();
-        $this->assertStringContainsString('APP_KEY=123 # Change this', $result);
+        $this->assertStringContainsString('APP_KEY="123" # Change this', $result);
 
         $env->set('APP_KEY', 'this is a test');
         $result = $env->render();

--- a/tests/fixtures/env/edge-cases.env
+++ b/tests/fixtures/env/edge-cases.env
@@ -17,6 +17,8 @@ ENV_TEST="1"
 
 EMPTY_VAR=
 
+VAR_NO_VALUE
+
 MULTILINE_VAR="This is a multiline
 string that spans over multiple
 lines"

--- a/tests/fixtures/env/edge-cases.env
+++ b/tests/fixtures/env/edge-cases.env
@@ -14,3 +14,18 @@ APP_EXAMPLE="test"
 ENV_TEST="1"
 
 #ENV_COMMENT=1
+
+EMPTY_VAR=
+
+MULTILINE_VAR="This is a multiline
+string that spans over multiple
+lines"
+
+MULTILINE_VAR_WITH_COMMENT="This is another
+multiline string that spans over multiple
+lines and has a comment"   # Additional comment
+
+ESCAPED_LINE="This is a string with an \"escaped\" quote"
+
+ESCAPED_MULTILINE="This is a multiline
+wtih an \"escaped\" quote within"

--- a/tests/fixtures/env/edge-cases.env
+++ b/tests/fixtures/env/edge-cases.env
@@ -1,0 +1,16 @@
+# WINTERCMS
+
+APP_DEBUG=true
+APP_URL="http://localhost"
+
+# HELLO WORLD
+
+APP_KEY="changeme" # Change this
+
+APP_EXAMPLE="test"
+
+#ENV_COMMENT="1"
+
+ENV_TEST="1"
+
+#ENV_COMMENT=1


### PR DESCRIPTION
This PR is a bit overkill, but resolves the issue reported in https://github.com/wintercms/laravel-config-writer/issues/1.

The problem was previously each line was parsed as a single entity, i.e. a line could be either a `comment` or a `env` entry, but never two things.

The new approach provided by this PR is to use a proper `Lexer` to convert the source into tokens. By doing this, multiple tokens can exist on the same line.

This ensures that the following:
```env
# WINTERCMS

APP_DEBUG=true
APP_URL="http://localhost"

# HELLO WORLD

APP_KEY="changeme" # Change this

APP_EXAMPLE="test"

#ENV_COMMENT="1"

ENV_TEST="1"

#ENV_COMMENT=1
```
Can be interpreted and updated, preserving the original whitespace and comments.

I've added some additional tests to confirm the newly supported functionality