### PR TITLE
Add support for using strict types in configs

### DIFF
--- a/src/ArrayFile.php
+++ b/src/ArrayFile.php
@@ -305,6 +305,7 @@ class ArrayFile extends DataFile implements DataFileInterface
             switch (get_class($item)) {
                 case Stmt\Use_::class:
                 case Stmt\Expression::class:
+                case Stmt\Declare_::class:
                     break;
                 case Stmt\Return_::class:
                     return $index;

--- a/tests/ArrayFileTest.php
+++ b/tests/ArrayFileTest.php
@@ -835,6 +835,17 @@ PHP;
         );
     }
 
+    public function testSingleLineCommentSubItem()
+    {
+        $file = __DIR__ . '/fixtures/array/single-line-comments-subitem.php';
+        $arrayFile = ArrayFile::open($file);
+
+        $this->assertEquals(
+            str_replace("\r", '', file_get_contents($file)),
+            str_replace("\r", '', $arrayFile->render())
+        );
+    }
+
     public function testStrictFileTypes()
     {
         $file = __DIR__ . '/fixtures/array/strict-file-types.php';

--- a/tests/ArrayFileTest.php
+++ b/tests/ArrayFileTest.php
@@ -842,6 +842,6 @@ PHP;
 
         $code = $arrayFile->render();
 
-        $this->assertStringContainsString('declare(strict_types=true)', $code);
+        $this->assertStringContainsString('declare', $code);
     }
 }

--- a/tests/ArrayFileTest.php
+++ b/tests/ArrayFileTest.php
@@ -835,14 +835,13 @@ PHP;
         );
     }
 
-    public function testSingleLineCommentSubItem()
+    public function testStrictFileTypes()
     {
-        $file = __DIR__ . '/fixtures/array/single-line-comments-subitem.php';
+        $file = __DIR__ . '/fixtures/array/strict-file-types.php';
         $arrayFile = ArrayFile::open($file);
 
-        $this->assertEquals(
-            str_replace("\r", '', file_get_contents($file)),
-            str_replace("\r", '', $arrayFile->render())
-        );
+        $code = $arrayFile->render();
+
+        $this->assertStringContainsString('declare(strict_types=true)', $code);
     }
 }

--- a/tests/fixtures/array/strict-file-types.php
+++ b/tests/fixtures/array/strict-file-types.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'foo' => Response::HTTP_OK
+];


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->

Greetings!

This PR aims to add support for config files that have `declare(strict_types=true);` at the top of the file like so

```php
<?php

declare (strict_types=1);

use Illuminate\Support\Facades\Facade;

return [

    'aliases' => Facade::defaultAliases()->merge([
        // 'Example' => App\Facades\Example::class,
        'Operator' => App\Operations\Operator::class,
    ])->toArray(),

];
```

At present any project that tries to use this package, while also having strict types in the config will not work. The ArrayFile will throw an exception that there is no return even if there is.

I'm not sure how wide of a practice it is to use strict types, but it's quite frequent at my work and my personal projects.
