### PR TITLE
Added init support for php-parser v5.5

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -29,7 +29,7 @@ jobs:
           key: ${{ env.key }}
 
       - name: Cache extensions
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.extcache.outputs.dir }}
           key: ${{ steps.extcache.outputs.key }}

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -18,7 +18,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout changes
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup extension cache
         id: extcache
@@ -46,7 +46,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout changes
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup extension cache
         id: extcache
@@ -35,7 +35,7 @@ jobs:
           key: ${{ env.key }}
 
       - name: Cache extensions
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.extcache.outputs.dir }}
           key: ${{ steps.extcache.outputs.key }}
@@ -52,7 +52,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4.0 || ^8.0",
-        "nikic/php-parser": "^4.10"
+        "nikic/php-parser": "^5.5"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "authors": [
         {
             "name": "Jack Wilkinson",
-            "email": "me@jaxwilko.com",
+            "email": "me@jackwilky.com",
             "role": "Original author"
         },
         {

--- a/src/Printer/ArrayPrinter.php
+++ b/src/Printer/ArrayPrinter.php
@@ -229,8 +229,9 @@ class ArrayPrinter extends Standard
             }
 
             // 91 represents the token id for a new array starting, at which point we no longer want to collect
-            // the comments from inside, as they do not belong to the node we're looking at
-            if ($tokens[$pos]->id === 91) {
+            // the comments from inside, as they do not belong to the node we're looking at, 40 is open paren for old
+            // syntax arrays
+            if ($tokens[$pos]->id === 91 || $tokens[$pos]->id === T_ARRAY && $tokens[$pos + 1]->id === 40) {
                 break;
             }
 

--- a/src/Printer/ArrayPrinter.php
+++ b/src/Printer/ArrayPrinter.php
@@ -17,24 +17,6 @@ class ArrayPrinter extends Standard
     protected ?ParserAbstract $parser = null;
 
     /**
-     * Creates a pretty printer instance using the given options.
-     *
-     * Supported options:
-     *  * bool $shortArraySyntax = false: Whether to use [] instead of array() as the default array
-     *                                    syntax, if the node does not specify a format.
-     *
-     * @param array<string, bool> $options Dictionary of formatting options
-     */
-    public function __construct(array $options = [])
-    {
-        if (!isset($options['shortArraySyntax'])) {
-            $options['shortArraySyntax'] = true;
-        }
-
-        parent::__construct($options);
-    }
-
-    /**
      * Proxy of `prettyPrintFile` to allow for adding lexer token checking support during render.
      * Pretty prints a file of statements (includes the opening <?php tag if it is required).
      *

--- a/tests/ArrayFileTest.php
+++ b/tests/ArrayFileTest.php
@@ -857,6 +857,17 @@ PHP;
         );
     }
 
+    public function testSingleLineCommentSubItemOldSchool()
+    {
+        $file = __DIR__ . '/fixtures/array/old-school-array-single-line-comments-subitem.php';
+        $arrayFile = ArrayFile::open($file);
+
+        $this->assertEquals(
+            str_replace("\r", '', file_get_contents($file)),
+            str_replace("\r", '', $arrayFile->render())
+        );
+    }
+
     public function testStrictFileTypes()
     {
         $file = __DIR__ . '/fixtures/array/strict-file-types.php';

--- a/tests/ArrayFileTest.php
+++ b/tests/ArrayFileTest.php
@@ -846,6 +846,17 @@ PHP;
         );
     }
 
+    public function testSingleLineCommentSubItemComplex()
+    {
+        $file = __DIR__ . '/fixtures/array/single-line-comments-subitem-complex.php';
+        $arrayFile = ArrayFile::open($file);
+
+        $this->assertEquals(
+            str_replace("\r", '', file_get_contents($file)),
+            str_replace("\r", '', $arrayFile->render())
+        );
+    }
+
     public function testStrictFileTypes()
     {
         $file = __DIR__ . '/fixtures/array/strict-file-types.php';

--- a/tests/ArrayFileTest.php
+++ b/tests/ArrayFileTest.php
@@ -824,6 +824,28 @@ PHP;
         $this->assertStringNotContainsString(str_repeat(' ', 12) . '|', $code);
     }
 
+    public function testMultiLineNestedCommentsSimple()
+    {
+        $file = __DIR__ . '/fixtures/array/multi-line-nested-comments-simple.php';
+        $arrayFile = ArrayFile::open($file);
+
+        $this->assertEquals(
+            str_replace("\r", '', file_get_contents($file)),
+            str_replace("\r", '', $arrayFile->render())
+        );
+    }
+
+    public function testMultiLineNestedCommentsComplex()
+    {
+        $file = __DIR__ . '/fixtures/array/multi-line-nested-comments-complex.php';
+        $arrayFile = ArrayFile::open($file);
+
+        $this->assertEquals(
+            str_replace("\r", '', file_get_contents($file)),
+            str_replace("\r", '', $arrayFile->render())
+        );
+    }
+
     public function testSingleLineComment()
     {
         $file = __DIR__ . '/fixtures/array/single-line-comments.php';

--- a/tests/fixtures/array/multi-line-nested-comments-complex.php
+++ b/tests/fixtures/array/multi-line-nested-comments-complex.php
@@ -1,0 +1,73 @@
+<?php
+
+return [
+    'throttle' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Enable throttling of Backend authentication attempts
+        |--------------------------------------------------------------------------
+        |
+        | If set to true, users will be given a limited number of attempts to sign
+        | in to the Backend before being blocked for a specified number of minutes.
+        |
+        */
+
+        'enabled' => true,
+        'database' => [
+            'table' => 'comments',
+            'columns' => [],
+        ],
+
+        // 'database' => [
+        //     'table' => 'files',
+        //     'columns' => []
+        // ]
+
+        'wintercms' => [
+            'is_awesome' => true,
+        ],
+        //        'example' => [
+        //            'testing' => 'test'
+        //        ],
+    ],
+    'demo' => [
+        'wintercms' => [
+            'is_awesome' => true,
+        ],
+        // 'example' => [
+        //     'foo' => 'bar',
+        // ],
+    ],
+    'demo_example' => [
+        'wintercms' => [
+            'is_awesome' => true,
+        ],
+
+        // 'example' => [
+        //     'foo' => 'bar',
+        // ],
+        array(
+            'a',
+        ),
+        'b' => [
+            'x' => 'y',
+            '',
+            // Hello world
+            'Somerthing' => array(
+                'test' => 'ing',
+                /**
+                 * This is a little test
+                 * Maybe
+                 */
+            ),
+            // How complex can we make it?
+        ],
+        /**
+         * Very complex
+         */
+        // [
+        //     'x' => 'y',
+        // ]
+    ],
+];

--- a/tests/fixtures/array/multi-line-nested-comments-simple.php
+++ b/tests/fixtures/array/multi-line-nested-comments-simple.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'throttle' => [
+        'enabled' => true,
+        'database' => [
+            'table' => 'comments',
+            'columns' => [],
+        ],
+        'wintercms' => [
+            'is_awesome' => true,
+        ],
+        //        'example' => [
+        //            'testing' => 'test'
+        //        ],
+    ],
+    'demo' => [
+        'wintercms' => [
+            'is_awesome' => true,
+        ],
+        // 'example' => [
+        //     'foo' => 'bar',
+        // ],
+    ],
+];

--- a/tests/fixtures/array/old-school-array-single-line-comments-subitem.php
+++ b/tests/fixtures/array/old-school-array-single-line-comments-subitem.php
@@ -1,0 +1,92 @@
+<?php
+
+return array(
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Broadcaster
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default broadcaster that will be used by the
+    | framework when an event needs to be broadcast. You may set this to
+    | any of the connections defined in the "connections" array below.
+    |
+    | Supported: "pusher", "ably", "redis", "log", "null"
+    |
+    */
+
+    'default' => env('BROADCAST_DRIVER', 'null'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Broadcast Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define all of the broadcast connections that will be used
+    | to broadcast events to other systems or over websockets. Samples of
+    | each available type of connection are provided inside this array.
+    |
+    */
+
+    'connections' => array(
+        'pusher' => array(
+            'app_id' => env('PUSHER_APP_ID'),
+            'client_options' => array(
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
+            ),
+            'empty' => array(
+                // This is a multi line comment
+                // See, another line
+            ),
+            'empty_star' => array(
+                /**
+                 * This is many line
+                 */
+            ),
+            'empty_star_multiple' => array(
+                /**
+                 * This is many line
+                 */
+                /**
+                 * This is many many line
+                 */
+            ),
+            'options' => array(
+
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
+
+                array(
+                    // Ahead Comment
+                    'driver' => 'pusher',
+                    // Under
+                    'options' => array(
+                        // Inside
+                    ),
+                ),
+            ),
+            'driver' => 'pusher',
+            'key' => env('PUSHER_APP_KEY'),
+            'options2' => array(
+                // This is a test
+                'cluster' => env('PUSHER_APP_CLUSTER'),
+                // Testing 1234
+                'useTLS' => true,
+            ),
+            'secret' => env('PUSHER_APP_SECRET'),
+        ),
+        'ably' => array(
+            'driver' => 'ably',
+            'key' => env('ABLY_KEY'),
+        ),
+        'redis' => array(
+            'connection' => 'default',
+            'driver' => 'redis',
+        ),
+        'log' => array(
+            'driver' => 'log',
+        ),
+        'null' => array(
+            'driver' => 'null',
+        ),
+    ),
+);

--- a/tests/fixtures/array/single-line-comments-subitem-complex.php
+++ b/tests/fixtures/array/single-line-comments-subitem-complex.php
@@ -1,0 +1,92 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Broadcaster
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default broadcaster that will be used by the
+    | framework when an event needs to be broadcast. You may set this to
+    | any of the connections defined in the "connections" array below.
+    |
+    | Supported: "pusher", "ably", "redis", "log", "null"
+    |
+    */
+
+    'default' => env('BROADCAST_DRIVER', 'null'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Broadcast Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define all of the broadcast connections that will be used
+    | to broadcast events to other systems or over websockets. Samples of
+    | each available type of connection are provided inside this array.
+    |
+    */
+
+    'connections' => [
+        'pusher' => [
+            'app_id' => env('PUSHER_APP_ID'),
+            'client_options' => [
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
+            ],
+            'empty' => [
+                // This is a multi line comment
+                // See, another line
+            ],
+            'empty_star' => [
+                /**
+                 * This is many line
+                 */
+            ],
+            'empty_star_multiple' => [
+                /**
+                 * This is many line
+                 */
+                /**
+                 * This is many many line
+                 */
+            ],
+            'options' => [
+
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
+
+                [
+                    // Ahead Comment
+                    'driver' => 'pusher',
+                    // Under
+                    'options' => [
+                        // Inside
+                    ],
+                ],
+            ],
+            'driver' => 'pusher',
+            'key' => env('PUSHER_APP_KEY'),
+            'options2' => [
+                // This is a test
+                'cluster' => env('PUSHER_APP_CLUSTER'),
+                // Testing 1234
+                'useTLS' => true,
+            ],
+            'secret' => env('PUSHER_APP_SECRET'),
+        ],
+        'ably' => [
+            'driver' => 'ably',
+            'key' => env('ABLY_KEY'),
+        ],
+        'redis' => [
+            'connection' => 'default',
+            'driver' => 'redis',
+        ],
+        'log' => [
+            'driver' => 'log',
+        ],
+        'null' => [
+            'driver' => 'null',
+        ],
+    ],
+];

--- a/tests/fixtures/array/single-line-comments-subitem.php
+++ b/tests/fixtures/array/single-line-comments-subitem.php
@@ -30,17 +30,17 @@ return [
 
     'connections' => [
         'pusher' => [
-            'app_id' => env('PUSHER_APP_ID'),
+            'app_id' => env('PUSHER_APP_ID', false),
             'client_options' => [
                 // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
             ],
             'driver' => 'pusher',
-            'key' => env('PUSHER_APP_KEY'),
+            'key' => env('PUSHER_APP_KEY', true),
             'options' => [
-                'cluster' => env('PUSHER_APP_CLUSTER'),
+                'cluster' => env('PUSHER_APP_CLUSTER', null),
                 'useTLS' => true,
             ],
-            'secret' => env('PUSHER_APP_SECRET'),
+            'secret' => env('PUSHER_APP_SECRET', T_BOOL_CAST),
         ],
         'ably' => [
             'driver' => 'ably',


### PR DESCRIPTION
This is an initial pass, there is an issue where comments which are the last item in an array have no node to be attached to, see: https://github.com/nikic/PHP-Parser/issues/445#issuecomment-348810236.

Fixes #6 