### PR TITLE
Added support for return having a nl prefix if one was there previously

### DIFF
--- a/src/Printer/ArrayPrinter.php
+++ b/src/Printer/ArrayPrinter.php
@@ -33,11 +33,6 @@ class ArrayPrinter extends Standard
     public const T_PAREN_CLOSE = 41;
 
     /**
-     * @var int T_APPARENT_WHITESPACE represents the token id for whitespace
-     */
-    public const T_APPARENT_WHITESPACE = 396;
-
-    /**
      * @var array LIST_T_OPENS lists all open tokens, used instead of creating a new array within comment detection
      */
     public const LIST_T_OPENS = [
@@ -158,8 +153,8 @@ class ArrayPrinter extends Standard
         // whitespace token was a double return, then prefix a \n
         $prefix = (
             count($previousTokens) > 1
-            && $previousTokens[1]->id === static::T_APPARENT_WHITESPACE
-            && $previousTokens[0]->id !== static::T_APPARENT_WHITESPACE
+            && $previousTokens[1]->id === T_WHITESPACE
+            && $previousTokens[0]->id !== T_WHITESPACE
             && $previousTokens[1]->text === "\n\n"
         ) ? "\n" : '';
 

--- a/src/Printer/ArrayPrinter.php
+++ b/src/Printer/ArrayPrinter.php
@@ -155,8 +155,8 @@ class ArrayPrinter extends Standard
             count($previousTokens) > 1
             && $previousTokens[1]->id === T_WHITESPACE
             && $previousTokens[0]->id !== T_WHITESPACE
-            && $previousTokens[1]->text === "\n\n"
-        ) ? "\n" : '';
+            && $previousTokens[1]->text === PHP_EOL . PHP_EOL
+        ) ? PHP_EOL : '';
 
         return $prefix . 'return' . (null !== $node->expr ? ' ' . $this->p($node->expr) : '') . ';';
     }

--- a/src/Printer/ArrayPrinter.php
+++ b/src/Printer/ArrayPrinter.php
@@ -155,8 +155,8 @@ class ArrayPrinter extends Standard
             count($previousTokens) > 1
             && $previousTokens[1]->id === T_WHITESPACE
             && $previousTokens[0]->id !== T_WHITESPACE
-            && $previousTokens[1]->text === PHP_EOL . PHP_EOL
-        ) ? PHP_EOL : '';
+            && $previousTokens[1]->text === "\n\n"
+        ) ? "\n" : '';
 
         return $prefix . 'return' . (null !== $node->expr ? ' ' . $this->p($node->expr) : '') . ';';
     }

--- a/src/Printer/ArrayPrinter.php
+++ b/src/Printer/ArrayPrinter.php
@@ -155,7 +155,7 @@ class ArrayPrinter extends Standard
             count($previousTokens) > 1
             && $previousTokens[1]->id === T_WHITESPACE
             && $previousTokens[0]->id !== T_WHITESPACE
-            && $previousTokens[1]->text === "\n\n"
+            && $previousTokens[1]->text === PHP_EOL . PHP_EOL
         ) ? "\n" : '';
 
         return $prefix . 'return' . (null !== $node->expr ? ' ' . $this->p($node->expr) : '') . ';';

--- a/tests/ArrayFileTest.php
+++ b/tests/ArrayFileTest.php
@@ -245,9 +245,49 @@ class ArrayFileTest extends TestCase
 <?php
 
 use Symfony\Component\HttpFoundation\Response;
+
 return [
     'foo' => Response::HTTP_OK,
     'bar' => Response::HTTP_I_AM_A_TEAPOT,
+];
+
+PHP;
+
+        $this->assertEquals(str_replace("\r", '', $expected), $arrayFile->render());
+    }
+
+    public function testConfigImportComplex()
+    {
+        $arrayFile = ArrayFile::open(__DIR__ . '/fixtures/array/import-complex.php');
+
+        $expected = <<<PHP
+<?php
+
+use Symfony\Component\HttpFoundation\Response;
+use Example\EnumExample;
+
+return [
+    'foo' => Response::HTTP_OK,
+    'bar' => EnumExample::Value->value,
+];
+
+PHP;
+
+        $this->assertEquals(str_replace("\r", '', $expected), $arrayFile->render());
+    }
+
+    public function testConfigImportCompact()
+    {
+        $arrayFile = ArrayFile::open(__DIR__ . '/fixtures/array/import-compact.php');
+
+        $expected = <<<PHP
+<?php
+
+use Symfony\Component\HttpFoundation\Response;
+use Example\EnumExample;
+return [
+    'foo' => Response::HTTP_OK,
+    'bar' => EnumExample::Value->value,
 ];
 
 PHP;
@@ -264,6 +304,7 @@ PHP;
 <?php
 
 use Symfony\Component\HttpFoundation\Response;
+
 return [
     'foo' => Response::HTTP_CONFLICT,
     'bar' => Response::HTTP_I_AM_A_TEAPOT,
@@ -282,6 +323,7 @@ PHP;
 <?php
 
 \$bar = nl2br("Hello\\nWorld");
+
 return [
     'foo' => \$bar,
 ];
@@ -792,6 +834,7 @@ include(__DIR__ . '/sample-array-file.php');
 include_once(__DIR__ . '/sample-array-file.php');
 require(__DIR__ . '/sample-array-file.php');
 require_once(__DIR__ . '/sample-array-file.php');
+
 return [
     'foo' => array_merge(include(__DIR__ . '/sample-array-file.php'), [
         'bar' => 'foo',

--- a/tests/fixtures/array/import-compact.php
+++ b/tests/fixtures/array/import-compact.php
@@ -1,0 +1,7 @@
+<?php
+use Symfony\Component\HttpFoundation\Response;
+use Example\EnumExample;
+return [
+    'foo' => Response::HTTP_OK,
+    'bar' => EnumExample::Value->value
+];

--- a/tests/fixtures/array/import-complex.php
+++ b/tests/fixtures/array/import-complex.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Response;
+
+use Example\EnumExample;
+
+return [
+    'foo' => Response::HTTP_OK,
+    'bar' => EnumExample::Value->value
+];


### PR DESCRIPTION
This PR adds support for including a NL prior to the return statement if one was there previously.

This should fix https://github.com/wintercms/laravel-config-writer/issues/10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for imported constants and enum values in array configuration output.
  * Support for expressions used in imported values when rendering arrays.

* **Bug Fixes**
  * Preserve blank line before return statements for readable formatting.
  * Ensure a trailing return block is added after include statements.

* **Tests**
  * Added coverage and fixtures for complex/compact imports, updating imports, expression handling, and include-formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->